### PR TITLE
(MAINT) Update dependencies and set parent project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: clojure
-lein: lein2
+lein: 2.7.1
 jdk:
 - oraclejdk7
 - openjdk7
+- oraclejdk8
 script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/dev/example/bootstrap.cfg
+++ b/dev/example/bootstrap.cfg
@@ -3,3 +3,4 @@ puppetlabs.trapperkeeper.services.metrics.metrics-service/metrics-service
 puppetlabs.trapperkeeper.services.status.status-service/status-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
+puppetlabs.trapperkeeper.services.scheduler.scheduler-service/scheduler-service

--- a/dev/example/comidi_metrics_web_app.clj
+++ b/dev/example/comidi_metrics_web_app.clj
@@ -98,7 +98,7 @@
                                                        :mean (get-mean :baz-task1-timer)}
                                            :baz-task2 {:count (get-count :baz-task2-timer)
                                                        :mean (get-mean :baz-task2-timer)}})))]
-        {:is-running :true
+        {:state :running
          :status status}))))
 
 (tk/defservice example-web-service

--- a/project.clj
+++ b/project.clj
@@ -1,22 +1,20 @@
-(def ks-version "1.1.0")
-(def tk-version "1.1.1")
-
 (defproject puppetlabs/trapperkeeper-comidi-metrics "0.1.3-SNAPSHOT"
   :description "Comidi/HTTP Metrics for Trapperkeeper"
   :url "http://github.com/puppetlabs/trapperkeeper-comidi-metrics"
 
+  :min-lein-version "2.7.1"
+
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-time "0.7.0"]
-                 [slingshot "0.12.2"]
-                 [org.slf4j/slf4j-api "1.7.7"]
-                 [commons-io "2.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.3.0"]
+                   :inherit [:managed-dependencies]}
 
-                 [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/trapperkeeper ~tk-version :exclusions [org.clojure/tools.macro]]
-                 [puppetlabs/trapperkeeper-metrics "0.1.1"]
-                 [puppetlabs/comidi "0.1.3"]]
+  :dependencies [[org.clojure/clojure]
+                 [prismatic/schema]
+                 [puppetlabs/trapperkeeper-metrics]
+                 [puppetlabs/comidi]]
+
+  :plugins [[lein-parent "0.3.1"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
@@ -24,11 +22,11 @@
                                      :sign-releases false}]]
 
   :profiles {:dev {:source-paths ["dev"]
-                   :dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :exclusions [org.clojure/tools.macro]]
-                                  [puppetlabs/kitchensink ~ks-version :classifier "test"]
-                                  [puppetlabs/trapperkeeper-status "0.1.1"]
-                                  [puppetlabs/http-client "0.4.4"]
-                                  [puppetlabs/trapperkeeper-webserver-jetty9 "1.3.1"]]}}
+                   :dependencies [[puppetlabs/trapperkeeper :classifier "test"]
+                                  [puppetlabs/kitchensink :classifier "test"]
+                                  [puppetlabs/trapperkeeper-status]
+                                  [puppetlabs/http-client]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9]]}}
 
   :aliases {"example" ["run" "-m" "example.comidi-metrics-web-app"]
             "example-data" ["run" "-m" "example.traffic-generator"]})


### PR DESCRIPTION
This patch updates the dependencies in project.clj and adds
puppetlabs/clj-parent as the source of most dependency version using
clj-parent. Some tests are also updated to reflect changes in the
trapperkeeper-status service.